### PR TITLE
copying files over from traits-futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: generic
+dist: xenial
+
+env:
+  global:
+    - INSTALL_EDM_VERSION=3.0.1
+      PYTHONUNBUFFERED="1"
+
+matrix:
+  include:
+    - env: RUNTIME=3.6
+    - os: osx
+      env: RUNTIME=3.6
+  fast_finish: true
+
+cache:
+  directories:
+    - "~/.cache"
+
+before_install:
+  - mkdir -p "${HOME}/.cache/download"
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sh -e ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then sh -e ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
+  - edm install -y wheel click
+install:
+  - edm run -- python etstool.py install --runtime=${RUNTIME}
+script:
+  - edm run -- python etstool.py flake8 --runtime=${RUNTIME}
+  - edm run -- python etstool.py test --runtime=${RUNTIME}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+build: false
+skip_branch_with_pr: true
+platform: x64
+
+environment:
+  global:
+    PYTHONUNBUFFERED: "1"
+    INSTALL_EDM_VERSION: "3.0.1"
+
+  matrix:
+    - RUNTIME: '3.6'
+
+matrix:
+  fast_finish: true
+
+cache:
+  - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
+
+init:
+  - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
+  - ps: md C:/Users/appveyor/.cache -Force
+
+install:
+  - install-edm-windows.cmd
+  - edm install -y wheel click
+  - edm run -- python etstool.py install --runtime=%RUNTIME%
+
+test_script:
+  - edm run -- python etstool.py flake8 --runtime=%RUNTIME%
+  - edm run -- python etstool.py test --runtime=%RUNTIME%

--- a/ets_copyright_checker/__init__.py
+++ b/ets_copyright_checker/__init__.py
@@ -1,0 +1,206 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Copyright header checker
+
+This file provides a checker for the presence and accuracy of the Enthought
+open source copyright header in all Python source files, along with
+a flake8 wrapper that makes the check available as a flake8 plugin.
+"""
+
+import datetime
+import re
+
+#: Regular expression to match things of the form "1985" or of the form
+#: "1985-1999".
+YEAR_RANGE = r"(?P<start_year>\d{4})(?:\-(?P<end_year>\d{4}))?"
+
+#: Pattern (as a regular expression) for the ETS copyright header.
+ETS_COPYRIGHT_HEADER_PATTERN = r"""
+# \(C\) Copyright {year_range} Enthought, Inc\., Austin, TX
+# All rights reserved\.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE\.txt and may be redistributed only under
+# the conditions described in the aforementioned license\. The license
+# is also available online at http://www\.enthought\.com/licenses/BSD\.txt
+#
+# Thanks for using Enthought open source!
+""".format(
+    year_range=YEAR_RANGE
+).lstrip()
+
+
+def parse_year_range(header_text):
+    """
+    Parse a copyright year range from a header string.
+
+    Looks for a year range of the form "1985" or "1985-1999", and
+    returns the start and end year.
+
+    If there are multiple year ranges, parses only the first.
+
+    Parameters
+    ----------
+    header_text : str
+        The text to be parsed. Could be the entire copyright header,
+        or a single line from the copyright header.
+
+    Returns
+    -------
+    start_year, end_year : int
+        Start year and end year described by the range.
+    match_pos : int
+        Position within the string at which the match occurred. This
+        is useful for error reporting.
+
+    Raises
+    ------
+    ValueError
+        If no year range is recognised from the given string.
+    """
+    years_match = re.search(YEAR_RANGE, header_text)
+    if not years_match:
+        raise ValueError("No year range found in the given string.")
+
+    start_year = int(years_match.group("start_year"))
+    end_year_str = years_match.group("end_year")
+    end_year = int(end_year_str) if end_year_str is not None else start_year
+    return start_year, end_year, years_match.start()
+
+
+class HeaderError:
+    """
+    Base class for the copyright header errors.
+    """
+
+    def __init__(self, lineno, col_offset):
+        self.lineno = lineno
+        self.col_offset = col_offset
+
+    @property
+    def full_message(self):
+        """
+        Full message in the form expected by flake8 (including the error code).
+        """
+        return "{} {}".format(self.code, self.message)
+
+
+class MissingCopyrightHeaderError(HeaderError):
+    """
+    Error reported when copyright header is missing, or doesn't match
+    the expected wording.
+    """
+
+    code = "H101"
+    message = (
+        "Copyright header is missing, or doesn't match the expected wording."
+    )
+
+
+class BadCopyrightEndYearError(HeaderError):
+    """
+    Error reported if the copyright header doesn't have the correct
+    year information in it.
+    """
+
+    code = "H102"
+
+    def __init__(self, lineno, col_offset, actual_end_year, expected_end_year):
+        super().__init__(lineno=lineno, col_offset=col_offset)
+        self.actual_end_year = actual_end_year
+        self.expected_end_year = expected_end_year
+
+    @property
+    def message(self):
+        return "Copyright end year ({}) should be {}.".format(
+            self.actual_end_year, self.expected_end_year
+        )
+
+
+def copyright_header(lines, end_year):
+    """
+    Check copyright header presence in a Python file.
+
+    Parameters
+    ----------
+    lines : list of string
+        The individual lines from the Python file, each terminated with
+        a newline character.
+    end_year : int
+        Expected end year, for example 2020.
+
+    Yields
+    ------
+    HeaderError
+        Errors found while checking the copyright header.
+    """
+    file_contents = "".join(lines)
+
+    # Empty files don't need a copyright header.
+    if not file_contents:
+        return
+
+    # Check that the file starts with the right copyright statement.
+    header_match = re.match(ETS_COPYRIGHT_HEADER_PATTERN, file_contents)
+    if header_match is None:
+        yield MissingCopyrightHeaderError(lineno=1, col_offset=0)
+        return
+
+    # Check the year range in the header.
+    _, actual_end_year, match_pos = parse_year_range(lines[0])
+    if actual_end_year != end_year:
+        yield BadCopyrightEndYearError(
+            lineno=1,
+            col_offset=match_pos,
+            actual_end_year=actual_end_year,
+            expected_end_year=end_year,
+        )
+
+
+class CopyrightHeaderExtension(object):
+    """
+    Flake8 extension for checking ETS copyright headers.
+    """
+
+    name = "headers"
+    version = "1.0.0"
+
+    def __init__(self, tree, lines):
+        self.lines = lines
+
+    @classmethod
+    def add_options(cls, option_manager):
+        option_manager.add_option(
+            "--copyright-end-year",
+            type="int",
+            metavar="year",
+            default=datetime.datetime.today().year,
+            parse_from_config=True,
+            help=(
+                "Expected end year in copyright statements "
+                "(default is the current year)"
+            ),
+        )
+
+    @classmethod
+    def parse_options(cls, options):
+        cls.copyright_end_year = options.copyright_end_year
+
+    def run(self):
+        end_year = self.copyright_end_year
+        for error in copyright_header(self.lines, end_year=end_year):
+            yield (
+                error.lineno,
+                error.col_offset,
+                error.full_message,
+                type(self),
+            )

--- a/ets_copyright_checker/tests/test_copyright_header.py
+++ b/ets_copyright_checker/tests/test_copyright_header.py
@@ -1,0 +1,87 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from ets_copyright_checker import (
+    BadCopyrightEndYearError,
+    copyright_header,
+    MissingCopyrightHeaderError,
+)
+
+
+class TestCopyrightHeader(unittest.TestCase):
+    def test_good_copyright(self):
+        file_contents = """\
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+"""
+        lines = file_contents.splitlines(keepends=True)
+        errors = list(copyright_header(lines, end_year=2020))
+        self.assertEqual(len(errors), 0)
+
+    def test_empty_file(self):
+        file_contents = ""
+        lines = file_contents.splitlines(keepends=True)
+        errors = list(copyright_header(lines, end_year=2020))
+        self.assertEqual(len(errors), 0)
+
+    def test_missing_copyright(self):
+        file_contents = """\
+# This Python file doesn't start with a copyright statement.
+
+import math
+
+x = math.sqrt(1729)
+"""
+        lines = file_contents.splitlines(keepends=True)
+        errors = list(copyright_header(lines, end_year=2020))
+        self.assertEqual(len(errors), 1)
+        error = errors[0]
+        self.assertIsInstance(error, MissingCopyrightHeaderError)
+        self.assertEqual(error.lineno, 1)
+        self.assertEqual(error.col_offset, 0)
+        self.assertTrue(
+            error.full_message.startswith(MissingCopyrightHeaderError.code)
+        )
+        self.assertIn(
+            "header is missing, or doesn't match", error.full_message
+        )
+
+    def test_well_formed_copyright_with_wrong_end_year(self):
+        file_contents = """\
+# (C) Copyright 2005-2010 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+"""
+        lines = file_contents.splitlines(keepends=True)
+        errors = list(copyright_header(lines, end_year=2020))
+        self.assertEqual(len(errors), 1)
+        error = errors[0]
+        self.assertIsInstance(error, BadCopyrightEndYearError)
+        self.assertEqual(error.lineno, 1)
+        self.assertEqual(error.col_offset, 16)
+        self.assertTrue(
+            error.full_message.startswith(BadCopyrightEndYearError.code)
+        )
+        self.assertIn("end year (2010) should be 2020", error.full_message)

--- a/etstool.py
+++ b/etstool.py
@@ -1,0 +1,160 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tasks for Test Runs
+===================
+
+This file is intended to be used with a python environment with the
+click library to automate the process of setting up test environments
+and running the test within them.  This improves repeatability and
+reliability of tests be removing many of the variables around the
+developer's particular Python environment.  Test environment setup and
+package management is performed using `EDM
+http://docs.enthought.com/edm/`_
+
+To use this to run you tests, you will need to install EDM and click
+into your working environment.  You will also need to have git
+installed to access required source code from github repositories.
+You can then do::
+
+    python etstool.py install --runtime=...
+
+to create a test environment from the current codebase and::
+
+    python etstool.py test --runtime=...
+
+to run tests in that environment.
+
+If you need to make frequent changes to the source, it is often convenient
+to install the source in editable mode::
+
+    python etstool.py install --editable --runtime=...
+
+Tests can still be run via the usual means in other environments if that suits
+a developer's purpose.
+"""
+
+import subprocess
+import sys
+
+import click
+
+
+# Directories and files that should be checked for flake8-cleanness.
+FLAKE8_TARGETS = [
+    "ets_copyright_checker",
+    "etstool.py",
+    "setup.py",
+]
+
+
+# All commands are implemented as subcommands of the cli group.
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
+@click.option(
+    "--editable/--not-editable",
+    default=False,
+    help="Install main package in 'editable' mode?  [default: --not-editable]",
+)
+def install(runtime, environment, editable):
+    """ Install project and dependencies into a clean EDM environment.=
+    """
+    parameters = get_parameters(runtime, environment)
+    # Install local source
+    install_ets_copyright_checker = "edm run -e {environment} -- pip install "
+    if editable:
+        install_ets_copyright_checker += "--editable "
+    install_ets_copyright_checker += "."
+
+    commands = [
+            "edm environments create {environment}"
+            " --force --version={runtime}",
+            "edm install -y -e {environment} flake8",
+            install_ets_copyright_checker
+        ]
+
+    click.echo("Creating environment '{environment}'".format(**parameters))
+    execute(commands, parameters)
+
+    click.echo("Done install")
+
+
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
+def test(runtime, environment):
+    """ Run the test suite in a given environment.
+    """
+    parameters = get_parameters(runtime, environment)
+    commands = [
+        "edm run -e {environment} -- python -Xfaulthandler -m unittest "
+        "discover -v ets_copyright_checker",
+    ]
+    click.echo("Running tests in '{environment}'".format(**parameters))
+    execute(commands, parameters)
+    click.echo("Done test")
+
+
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
+def flake8(runtime, environment):
+    """
+    Run flake8 on all Python files.
+    """
+    parameters = get_parameters(runtime, environment)
+    cmd = "edm run -e {environment} -- python -m flake8 ".format(**parameters)
+    cmd += " ".join(FLAKE8_TARGETS)
+
+    if subprocess.call(cmd.split()):
+        click.echo()
+        raise click.ClickException("Flake8 check failed.")
+    else:
+        click.echo("Flake8 check succeeded.")
+
+
+# ----------------------------------------------------------------------------
+# Utility routines
+# ----------------------------------------------------------------------------
+
+
+def get_parameters(runtime, environment):
+    """ Set up parameters dictionary for format() substitution """
+    parameters = {
+        "runtime": runtime,
+        "environment": environment,
+    }
+    if environment is None:
+        parameters["environment"] = \
+            "ets-copyright-checker-test-{runtime}".format(**parameters)
+    return parameters
+
+
+def execute(commands, parameters):
+    for command in commands:
+        click.echo("[EXECUTING] {}".format(command.format(**parameters)))
+        try:
+            subprocess.check_call(
+                [arg.format(**parameters) for arg in command.split()]
+            )
+        except subprocess.CalledProcessError as exc:
+            print(exc)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+install_edm() {
+    local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+
+    if [ ! -e "$EDM_INSTALLER_PATH" ]; then
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+    fi
+
+    bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"
+}
+
+install_edm

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+install_edm() {
+    local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+
+    if [ ! -e "$EDM_INSTALLER_PATH" ]; then
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+    fi
+
+    sudo installer -pkg "$EDM_INSTALLER_PATH" -target /
+}
+
+install_edm

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -1,0 +1,26 @@
+@ECHO OFF
+
+SETLOCAL EnableDelayedExpansion
+
+FOR /F "tokens=1,2,3 delims=." %%a in ("%INSTALL_EDM_VERSION%") do (
+    SET MAJOR=%%a
+    SET MINOR=%%b
+    SET REVISION=%%c
+)
+
+SET EDM_MAJOR_MINOR=%MAJOR%.%MINOR%
+SET EDM_PACKAGE=edm_cli_%INSTALL_EDM_VERSION%_x86_64.msi
+SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
+SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
+
+IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
+CALL msiexec /qn /i %EDM_INSTALLER_PATH% EDMAPPDIR=C:\Enthought\edm || GOTO error
+
+ENDLOCAL
+@ECHO.DONE
+EXIT
+
+:error:
+ENDLOCAL
+@ECHO.ERROR
+EXIT /b %ERRORLEVEL%

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import setuptools
+
+
+if __name__ == "__main__":
+    setuptools.setup(
+        name="ets_copyright_checker",
+        version="1.0.0",
+        description="flake8 plugin for checking copyright headers",
+        install_requires=["flake8"],
+        packages=["ets_copyright_checker", "ets_copyright_checker.tests"],
+        entry_points={
+            "flake8.extension": [
+                "H = ets_copyright_checker:CopyrightHeaderExtension",
+            ],
+        },
+    )


### PR DESCRIPTION
fixes #1 

This PR simply copies over the code from the traits-futures github repository - https://github.com/enthought/traits-futures/tree/master/copyright_header 
Additionally, as mentioned in this comment: https://github.com/enthought/ets-copyright-checker/issues/1#issuecomment-712216817 , it renames the package as `ets-copyright-checker` and sets the version number to be 1.0.0 instead of 1.2.0.