### PR TITLE
Setup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: generic
 dist: xenial
-services:
-  - xvfb
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-  - chmod +x install-edm-linux.sh
-  - chmod +x install-edm-osx.sh
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,13 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
+<<<<<<< Updated upstream
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
+=======
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sh -e ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then sh -e ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
+>>>>>>> Stashed changes
   - edm install -y wheel click
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: generic
+dist: xenial
+services:
+  - xvfb
+
+env:
+  global:
+    - INSTALL_EDM_VERSION=3.0.1
+      PYTHONUNBUFFERED="1"
+
+matrix:
+  include:
+    - env: RUNTIME=3.6
+    - os: osx
+      env: RUNTIME=3.6
+  fast_finish: true
+
+cache:
+  directories:
+    - "~/.cache"
+
+before_install:
+  - mkdir -p "${HOME}/.cache/download"
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
+  - edm install -y wheel click
+install:
+  - edm run -- python etstool.py install --runtime=${RUNTIME}
+script:
+  - edm run -- python etstool.py flake8 --runtime=${RUNTIME}
+  - edm run -- python etstool.py test --runtime=${RUNTIME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,8 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-<<<<<<< Updated upstream
-  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
-=======
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sh -e ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then sh -e ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
->>>>>>> Stashed changes
   - edm install -y wheel click
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
+  - chmod +x install-edm-linux.sh
+  - chmod +x install-edm-osx.sh
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 build: false
+skip_branch_with_pr: true
 platform: x64
 
 environment:
@@ -8,6 +9,9 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
+
+matrix:
+  fast_finish: true
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ install:
   - edm run -- python etstool.py install --runtime=%RUNTIME%
 
 test_script:
-  - edm run -- python etstool.py flake8 --runtime=${RUNTIME}
-  - edm run -- python etstool.py test --runtime=${RUNTIME}
+  - edm run -- python etstool.py flake8 --runtime=%RUNTIME%
+  - edm run -- python etstool.py test --runtime=%RUNTIME%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ environment:
 matrix:
   fast_finish: true
 
+branches:
+  only:
+    - master
+
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ init:
 
 install:
   - install-edm-windows.cmd
-  - edm install -y -e bootstrap click setuptools
+  - edm install -y wheel click
   - edm run -- python etstool.py install --runtime=%RUNTIME%
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,6 @@ environment:
 matrix:
   fast_finish: true
 
-branches:
-  only:
-    - master
-
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
   - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+build: false
+platform: x64
+
+environment:
+  global:
+    PYTHONUNBUFFERED: "1"
+    INSTALL_EDM_VERSION: "3.0.1"
+
+  matrix:
+    - RUNTIME: '3.6'
+
+cache:
+  - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
+
+init:
+  - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
+  - ps: md C:/Users/appveyor/.cache -Force
+
+install:
+  - install-edm-windows.cmd
+  - edm install -y -e bootstrap click setuptools
+  - edm run -- python etstool.py install --runtime=%RUNTIME%
+
+test_script:
+  - edm run -- python etstool.py flake8 --runtime=${RUNTIME}
+  - edm run -- python etstool.py test --runtime=${RUNTIME}

--- a/etstool.py
+++ b/etstool.py
@@ -1,0 +1,154 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tasks for Test Runs
+===================
+
+This file is intended to be used with a python environment with the
+click library to automate the process of setting up test environments
+and running the test within them.  This improves repeatability and
+reliability of tests be removing many of the variables around the
+developer's particular Python environment.  Test environment setup and
+package management is performed using `EDM
+http://docs.enthought.com/edm/`_
+
+To use this to run you tests, you will need to install EDM and click
+into your working environment.  You will also need to have git
+installed to access required source code from github repositories.
+You can then do::
+
+    python etstool.py install --runtime=...
+
+to create a test environment from the current codebase and::
+
+    python etstool.py test --runtime=...
+
+to run tests in that environment.
+
+If you need to make frequent changes to the source, it is often convenient
+to install the source in editable mode::
+
+    python etstool.py install --editable --runtime=...
+
+Tests can still be run via the usual means in other environments if that suits
+a developer's purpose.
+"""
+
+import subprocess
+import sys
+
+import click
+
+
+# Directories and files that should be checked for flake8-cleanness.
+FLAKE8_TARGETS = [
+    "ets-copyright-checker",
+    "etstool.py",
+    "setup.py",
+]
+
+
+# All commands are implemented as subcommands of the cli group.
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
+@click.option(
+    "--editable/--not-editable",
+    default=False,
+    help="Install main package in 'editable' mode?  [default: --not-editable]",
+)
+def install(runtime, environment, editable):
+    """ Install project and dependencies into a clean EDM environment.=
+    """
+    parameters = get_parameters(runtime, environment)
+    # Install local source
+    install_ets_copyright_checker = "edm run -e {environment} -- pip install "
+    if editable:
+        install_ets_copyright_checker += "--editable "
+    install_ets_copyright_checker += "."
+
+    commands = [
+            "edm environments create {environment} --force --version={runtime}",
+            "edm install -y -e {environment} flake8",
+            install_ets_copyright_checker
+        ]
+    
+    click.echo("Creating environment '{environment}'".format(**parameters))
+    execute(commands, parameters)
+
+    click.echo("Done install")
+
+
+def test(runtime, environment):
+    """ Run the test suite in a given environment.
+    """
+    parameters = get_parameters(runtime, environment)
+    commands = [
+        "edm run -e {environment} -- python -Xfaulthandler -m unittest "
+        "discover -v ets-copyright-checker",
+    ]
+    click.echo("Running tests in '{environment}'".format(**parameters))
+    execute(commands, parameters)
+    click.echo("Done test")
+
+
+def flake8(runtime, environment):
+    """
+    Run flake8 on all Python files.
+    """
+    parameters = get_parameters(runtime, environment)
+    cmd = "edm run -e {environment} -- python -m flake8".format(**parameters) 
+    cmd += " ".join(FLAKE8_TARGETS)
+
+    if subprocess.call(cmd):
+        click.echo()
+        raise click.ClickException("Flake8 check failed.")
+    else:
+        click.echo("Flake8 check succeeded.")
+
+
+# ----------------------------------------------------------------------------
+# Utility routines
+# ----------------------------------------------------------------------------
+
+
+def get_parameters(runtime, environment):
+    """ Set up parameters dictionary for format() substitution """
+    parameters = {
+        "runtime": runtime,
+        "environment": environment,
+    }
+    if environment is None:
+        parameters["environment"] = "ets-copyright-checker-test-{runtime}".format(
+            **parameters
+        )
+    return parameters
+
+
+def execute(commands, parameters):
+    for command in commands:
+        click.echo("[EXECUTING] {}".format(command.format(**parameters)))
+        try:
+            subprocess.check_call(
+                [arg.format(**parameters) for arg in command.split()]
+            )
+        except subprocess.CalledProcessError as exc:
+            print(exc)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/etstool.py
+++ b/etstool.py
@@ -81,11 +81,12 @@ def install(runtime, environment, editable):
     install_ets_copyright_checker += "."
 
     commands = [
-            "edm environments create {environment} --force --version={runtime}",
+            "edm environments create {environment}"
+            " --force --version={runtime}",
             "edm install -y -e {environment} flake8",
             install_ets_copyright_checker
         ]
-    
+
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 
@@ -116,7 +117,7 @@ def flake8(runtime, environment):
     Run flake8 on all Python files.
     """
     parameters = get_parameters(runtime, environment)
-    cmd = "edm run -e {environment} -- python -m flake8 ".format(**parameters) 
+    cmd = "edm run -e {environment} -- python -m flake8 ".format(**parameters)
     cmd += " ".join(FLAKE8_TARGETS)
 
     if subprocess.call(cmd.split()):
@@ -138,9 +139,8 @@ def get_parameters(runtime, environment):
         "environment": environment,
     }
     if environment is None:
-        parameters["environment"] = "ets-copyright-checker-test-{runtime}".format(
-            **parameters
-        )
+        parameters["environment"] = \
+            "ets-copyright-checker-test-{runtime}".format(**parameters)
     return parameters
 
 

--- a/etstool.py
+++ b/etstool.py
@@ -119,7 +119,7 @@ def flake8(runtime, environment):
     cmd = "edm run -e {environment} -- python -m flake8 ".format(**parameters) 
     cmd += " ".join(FLAKE8_TARGETS)
 
-    if subprocess.call(cmd):
+    if subprocess.call(cmd.split()):
         click.echo()
         raise click.ClickException("Flake8 check failed.")
     else:

--- a/etstool.py
+++ b/etstool.py
@@ -50,7 +50,7 @@ import click
 
 # Directories and files that should be checked for flake8-cleanness.
 FLAKE8_TARGETS = [
-    "ets-copyright-checker",
+    "ets_copyright_checker",
     "etstool.py",
     "setup.py",
 ]
@@ -101,7 +101,7 @@ def test(runtime, environment):
     parameters = get_parameters(runtime, environment)
     commands = [
         "edm run -e {environment} -- python -Xfaulthandler -m unittest "
-        "discover -v ets-copyright-checker",
+        "discover -v ets_copyright_checker",
     ]
     click.echo("Running tests in '{environment}'".format(**parameters))
     execute(commands, parameters)
@@ -116,7 +116,7 @@ def flake8(runtime, environment):
     Run flake8 on all Python files.
     """
     parameters = get_parameters(runtime, environment)
-    cmd = "edm run -e {environment} -- python -m flake8".format(**parameters) 
+    cmd = "edm run -e {environment} -- python -m flake8 ".format(**parameters) 
     cmd += " ".join(FLAKE8_TARGETS)
 
     if subprocess.call(cmd):

--- a/etstool.py
+++ b/etstool.py
@@ -92,6 +92,9 @@ def install(runtime, environment, editable):
     click.echo("Done install")
 
 
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
 def test(runtime, environment):
     """ Run the test suite in a given environment.
     """
@@ -105,6 +108,9 @@ def test(runtime, environment):
     click.echo("Done test")
 
 
+@cli.command()
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--environment", default=None, help="EDM environment to use")
 def flake8(runtime, environment):
     """
     Run flake8 on all Python files.

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+install_edm() {
+    local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+
+    if [ ! -e "$EDM_INSTALLER_PATH" ]; then
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+    fi
+
+    bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"
+}
+
+install_edm

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+install_edm() {
+    local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+
+    if [ ! -e "$EDM_INSTALLER_PATH" ]; then
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+    fi
+
+    sudo installer -pkg "$EDM_INSTALLER_PATH" -target /
+}
+
+install_edm

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -1,0 +1,26 @@
+@ECHO OFF
+
+SETLOCAL EnableDelayedExpansion
+
+FOR /F "tokens=1,2,3 delims=." %%a in ("%INSTALL_EDM_VERSION%") do (
+    SET MAJOR=%%a
+    SET MINOR=%%b
+    SET REVISION=%%c
+)
+
+SET EDM_MAJOR_MINOR=%MAJOR%.%MINOR%
+SET EDM_PACKAGE=edm_cli_%INSTALL_EDM_VERSION%_x86_64.msi
+SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
+SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
+
+IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
+CALL msiexec /qn /i %EDM_INSTALLER_PATH% EDMAPPDIR=C:\Enthought\edm || GOTO error
+
+ENDLOCAL
+@ECHO.DONE
+EXIT
+
+:error:
+ENDLOCAL
+@ECHO.ERROR
+EXIT /b %ERRORLEVEL%


### PR DESCRIPTION
Fixes #2 

Note this PR sits on top of #4.  I have this PR attempting to merge into the branch for #4 to keep the files changed specific to this PR.

This PR adds an `etstool.py` file (I followed the example of `traitsui` and `pyface`, but it may be better to have a `ci` directory more like `traits-futures`? see https://github.com/enthought/traits-futures/tree/master/ci)
It also adds `.travis.yml` and `appveyor.yml` files which run `flake8` and the test suite.

Also, the commit history is rather ugly (the only way I know of to debug this CI code is to make a new commit and push to run CI), so remember to squash merge!
