### PR TITLE
Fix copyright header year span to just 2020

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/flake8_ets/__init__.py
+++ b/flake8_ets/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/flake8_ets/copyright_header.py
+++ b/flake8_ets/copyright_header.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/flake8_ets/tests/test_copyright_header.py
+++ b/flake8_ets/tests/test_copyright_header.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/flake8_ets/version.py
+++ b/flake8_ets/version.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD


### PR DESCRIPTION
The copyright checker is first made public in Traits in 2020 (see https://github.com/enthought/traits/pull/749).

This PR fixes all copyright headers' start year.

(In two months time it will be 2020-2021)