### PR TITLE
Release flake8-ets 1.0.0

### DIFF
--- a/flake8_ets/version.py
+++ b/flake8_ets/version.py
@@ -13,4 +13,4 @@ Version information for the flake8_ets package
 """
 
 #: Full version of the flake8_ets package, as a string
-version = "1.0.0"
+version = "1.1.0.dev0"

--- a/flake8_ets/version.py
+++ b/flake8_ets/version.py
@@ -13,4 +13,4 @@ Version information for the flake8_ets package
 """
 
 #: Full version of the flake8_ets package, as a string
-version = "1.0.0.dev0"
+version = "1.0.0"


### PR DESCRIPTION
Part of #3 (not closing it yet).

The first commit is going to be the release commit (strictly speaking I should let CI to run on that commit too...).
The second commit bumps the version for the development of the next release.

Also tested locally so that if I install the package on the release commit, I see this:
```
$ git checkout 1.0.0
$ pip install .
$ flake8 --version
3.8.4 (headers: 1.0.0, mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0) CPython 3.8.2 on Darwin
```

(The "headers 1.0.0" refers to the copyright header plugin.)