### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6
-    - os: osx
-      env: RUNTIME=3.6
   fast_finish: true
 
 cache:
@@ -20,7 +18,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sh -e ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then sh -e ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME}


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration.