### PR TITLE
Fix incompatibility with flake8 6.0

### DIFF
--- a/.github/workflows/run-tests-no-edm.yml
+++ b/.github/workflows/run-tests-no-edm.yml
@@ -1,0 +1,26 @@
+name: Run test suite (no EDM)
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        runtime: ['3.8', '3.11']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Clone the source
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python_version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install local package
+      run: python -m pip install .
+    - name: Run style checks (including our own style checks)
+      run: python -m flake8 .
+    - name: Run tests
+      run: python -m unittest -v

--- a/flake8_ets/copyright_header.py
+++ b/flake8_ets/copyright_header.py
@@ -188,7 +188,7 @@ class CopyrightHeaderExtension(object):
     def add_options(cls, option_manager):
         option_manager.add_option(
             "--copyright-end-year",
-            type="int",
+            type=int,
             metavar="year",
             default=datetime.datetime.today().year,
             parse_from_config=True,


### PR DESCRIPTION
This PR:

- Adds a non-EDM-based test workflow (which fails with the bug identified with #22)
- Fixes that bug.

Closes #22 